### PR TITLE
Extract signTransaction() out of sendTransaction()

### DIFF
--- a/packages/cli/src/bin/zaster-send-transaction.ts
+++ b/packages/cli/src/bin/zaster-send-transaction.ts
@@ -38,7 +38,9 @@ async function sendTransaction ({ args, payment: payments = [] }) {
   })
 
   const transaction = await sdk.ledger.createTransaction(walletID, operations)
-  await sdk.ledger.sendTransaction(transaction)
+  const signedTransaction = await sdk.ledger.signTransaction(walletID, transaction)
+
+  await sdk.ledger.sendTransaction(signedTransaction)
 
   console.log(green(`Transaction successfully sent.`))
   process.exit(0)

--- a/packages/cli/test/zaster-send-transaction.test.ts
+++ b/packages/cli/test/zaster-send-transaction.test.ts
@@ -5,6 +5,7 @@ import * as temp from 'temp'
 import retry = require('async-retry')
 import got = require('got')
 import shell from './helpers/shell'
+import stripAnsi = require('strip-ansi')
 
 temp.track()
 
@@ -30,7 +31,7 @@ test('zaster-send-transaction can make a payment', async t => {
   const sourceKeypair = Keypair.random()
   const destinationKeypair = Keypair.random()
 
-  const passwordInput = 'samplePassword\nsamplePassword\n'
+  const passwordInput = 'samplePassword\n'
 
   await Promise.all([
     topUpByFriendbot(sourceKeypair.publicKey()),

--- a/packages/platform-api-spec/README.md
+++ b/packages/platform-api-spec/README.md
@@ -45,6 +45,10 @@ type options = {
 
 Asynchronously creates a transaction.
 
+### `signTransaction(wallet: Wallet, transaction: Transaction): Promise<Transaction>`
+
+Asynchronously sign a transaction with the wallet's private key.
+
 ### `sendTransaction(transaction: Transaction, options?: object): Promise<Transaction>`
 
 Dispatch transaction to network.

--- a/packages/platform-api-spec/index.ts
+++ b/packages/platform-api-spec/index.ts
@@ -8,6 +8,7 @@ export type Platform = {
   getWalletAddress (wallet: Wallet): Promise<string>,
   prepareNewWallet (wallet: Wallet, privateKey: string, options?: InitWalletOptions): Promise<void>,
   createTransaction (wallet: Wallet, operations: Operation[], options?: object): Promise<Transaction>,
+  signTransaction (wallet: Wallet, transaction: Transaction): Promise<Transaction>,
   sendTransaction (transaction: Transaction, options: InitWalletOptions): Promise<Transaction>
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -33,6 +33,7 @@ export type LedgerAPI = {
   getWalletBalance (walletID: string): Promise<BigNumber>,
   getWalletAddress (walletID: string): Promise<string>,
   createTransaction (walletID: string, operations: Operation[], options?: object): Promise<SDKTransaction>,
+  signTransaction (walletID: string, transaction: SDKTransaction): Promise<SDKTransaction>,
   sendTransaction (transaction: SDKTransaction): Promise<SDKTransaction>
 }
 
@@ -119,6 +120,14 @@ function createLedgerAPI (
         body,
         asset: wallet.asset,
         walletOptions: await wallet.getOptions()
+      }
+    },
+    async signTransaction (walletID: string, transaction: SDKTransaction): Promise<SDKTransaction> {
+      const { platform, wallet } = await openWalletByID(walletID)
+      const signedBody = await platform.signTransaction(wallet, transaction.body)
+      return {
+        ...transaction,
+        body: signedBody
       }
     },
     async sendTransaction (transaction: SDKTransaction): Promise<SDKTransaction> {

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -2,7 +2,7 @@ import { Big as BigNumber } from 'big.js'
 import { Keypair } from 'stellar-sdk'
 import { Asset, Wallet, InitWalletOptions } from '@wallet/platform-api'
 import { retrieveAccountData } from './horizon'
-export { createTransaction, sendTransaction } from './transactions'
+export { createTransaction, sendTransaction, signTransaction } from './transactions'
 
 export type PublicWalletData = {
   publicKey: string

--- a/packages/stellar/src/transactions.ts
+++ b/packages/stellar/src/transactions.ts
@@ -1,8 +1,10 @@
 import { Keypair, TransactionBuilder, Asset as StellarAsset, Operation as StellarOperation } from 'stellar-sdk'
-import { Operation, Transaction, Wallet, OperationType, PaymentOperation } from '@wallet/platform-api'
+import { Operation, Wallet, OperationType, PaymentOperation } from '@wallet/platform-api'
 import { getHorizonServer, retrieveAccountData, useNetwork } from './horizon'
 
-export async function createTransaction (wallet: Wallet, operations: Operation[], options = {}): Promise<Transaction> {
+export type StellarTransaction = any
+
+export async function createTransaction (wallet: Wallet, operations: Operation[], options = {}): Promise<StellarTransaction> {
   const { privateKey }: { privateKey: string } = await wallet.readPrivate()
   const { testnet } = await wallet.getOptions()
 
@@ -10,12 +12,19 @@ export async function createTransaction (wallet: Wallet, operations: Operation[]
   const account = await retrieveAccountData(keypair.publicKey(), { testnet })
 
   const transaction = buildTransaction(account, operations)
-  transaction.sign(keypair)
 
   return transaction
 }
 
-export async function sendTransaction (transaction: Transaction, options: { testnet?: boolean } = {}): Promise<Transaction> {
+export async function signTransaction (wallet: Wallet, transaction: StellarTransaction): Promise<StellarTransaction> {
+  const { privateKey }: { privateKey: string } = await wallet.readPrivate()
+  const keypair = Keypair.fromSecret(privateKey)
+
+  transaction.sign(keypair)
+  return transaction
+}
+
+export async function sendTransaction (transaction: StellarTransaction, options: { testnet?: boolean } = {}): Promise<StellarTransaction> {
   const testnet = Boolean(options.testnet)
   const horizon = getHorizonServer({ testnet })
 

--- a/packages/stellar/test/integration.test.ts
+++ b/packages/stellar/test/integration.test.ts
@@ -3,7 +3,15 @@ import { Big as BigNumber } from 'big.js'
 import { Keypair } from 'stellar-sdk'
 import got = require('got')
 import { OperationType } from '@wallet/platform-api'
-import { createPrivateKey, createTransaction, getAssets, getAddressBalance, getWalletBalance, sendTransaction } from '../src'
+import {
+  createPrivateKey,
+  createTransaction,
+  getAssets,
+  getAddressBalance,
+  getWalletBalance,
+  sendTransaction,
+  signTransaction
+} from '../src'
 
 const getAccountBalance = (restAccountData: any): string => restAccountData.balances.find(balance => balance.asset_type === 'native').balance
 
@@ -98,7 +106,7 @@ test('getWalletBalance() returns a zero-balance if account has not yet been acti
   t.true(BigNumber(0).eq(balance))
 })
 
-test('createTransaction() can create a tx that can be sent by sendTransaction()', async t => {
+test('can create a tx that can be signed and sent', async t => {
   const keypair = Keypair.fromSecret('SAOSYEJDOSY6SO75MVG3JBJA3VQICOAYGM3A7KR6Y6TBEN44MPJVDKRR')
   const destination = 'GAJT6T3FDVO3QXIRZJWXBYB7DYXLXMUFNW3AXDS52GAQKNZ23UQAOJRW'
 
@@ -120,7 +128,8 @@ test('createTransaction() can create a tx that can be sent by sendTransaction()'
   const transaction = await createTransaction(wallet, [
     { type: OperationType.Payment, amount: BigNumber(10), destination }
   ])
-  const sentTransaction = await sendTransaction(transaction, { testnet: true })
+  const signedTransaction = await signTransaction(wallet, transaction)
+  const sentTransaction = await sendTransaction(signedTransaction, { testnet: true })
 
   const [ resultingSourceBalance, resultingDestinationBalance ] = await Promise.all([
     getBalanceFromHorizon(`https://horizon-testnet.stellar.org/accounts/${keypair.publicKey()}`),


### PR DESCRIPTION
Signing should be a separate step, otherwise multi-signature wallets won't be possible in the future.