### PR TITLE
Fix error object output

### DIFF
--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,3 +1,4 @@
+import * as util from 'util'
 import { error as formatError, grey } from './formats'
 
 export function newInputError (message: string) {
@@ -16,7 +17,7 @@ export function handleCLIError (error) {
     console.error(formatError(messageLine))
     console.error(grey(stackLines.join('\n')))
   } else {
-    console.error(formatError(error))
+    console.error(formatError(util.inspect(error)))
   }
   process.exit(1)
 }


### PR DESCRIPTION
Only showed `[Object object]` in red on the console when the thrown error was not a proper `Error` instance, but just some other object (the stellar-sdk tends to do that).